### PR TITLE
同じ機種依存文字が複数含まれる場合でも、全部赤字で表示されるように

### DIFF
--- a/tools/special_charactor_check.html
+++ b/tools/special_charactor_check.html
@@ -9,7 +9,7 @@
             var forbidden_strings = "①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑯⑰⑱⑲⑳ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩ㍉㌔㌢㍍㌘㌧㌃㌶㍑㍗㌍㌦㌣㌫㍊㌻㎜㎝㎞㎎㎏㏄㎡㍻〝〟№㏍℡㊤㊥㊦㊧㊨㈱㈲㈹㍾㍽㍼∮∟⊿纊褜鍈銈蓜俉炻昱棈鋹曻彅丨仡仼伀伃伹佖侒侊侚侔俍偀倢俿倞偆偰偂傔僴僘兊兤冝冾凬刕劜劦勀勛匀匇匤卲厓厲叝﨎咜咊咩哿喆坙坥垬埈埇﨏塚增墲夋奓奛奝奣妤妺孖寀甯寘寬尞岦岺峵崧嵓﨑嵂嵭嶸嶹巐弡弴彧德忞恝悅悊惞惕愠惲愑愷愰憘戓抦揵摠撝擎敎昀昕昻昉昮昞昤晥晗晙晴晳暙暠暲暿曺朎朗杦枻桒柀栁桄棏﨓楨﨔榘槢樰橫橆橳橾櫢櫤毖氿汜沆汯泚洄涇浯涖涬淏淸淲淼渹湜渧渼溿澈澵濵瀅瀇瀨炅炫焏焄煜煆煇凞燁燾犱犾猤猪獷玽珉珖珣珒琇珵琦琪琩琮瑢璉璟甁畯皂皜皞皛皦益睆劯砡硎硤礰礼神祥禔福禛竑竧靖竫箞精絈絜綷綠緖繒罇羡羽茁荢荿菇菶葈蒴蕓蕙蕫﨟薰蘒﨡蠇裵訒訷詹誧誾諟諸諶譓譿賰賴贒赶﨣軏﨤逸遧郞都鄕鄧釚釗釞釭釮釤釥鈆鈐鈊鈺鉀鈼鉎鉙鉑鈹鉧銧鉷鉸鋧鋗鋙鋐﨧鋕鋠鋓錥錡鋻﨨錞鋿錝錂鍰鍗鎤鏆鏞鏸鐱鑅鑈閒隆﨩隝隯霳霻靃靍靏靑靕顗顥飼餧館馞驎髙髜魵魲鮏鮱鮻鰀鵰鵫鶴鸙黑ⅰⅱⅲⅳⅴⅵⅶⅷⅸⅹ￢￤ｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜｦﾝｧｨｩｪｫｬｭｮｯﾞﾟ｢｣".split("");
 
             forbidden_strings.forEach(function (forbidden_string) {
-                converted_string = converted_string.replace(forbidden_string, "<span  style='color:red;'>"+forbidden_string+"</span>");
+                converted_string = converted_string.split(forbidden_string).join("<span  style='color:red;'>"+forbidden_string+"</span>");
             });
 
             if (converted_string != input_string) {


### PR DESCRIPTION
(パッと赤字になる実装が思いつかなかったのですが、
jsでspanを入れて置換するのはとてもスマートに見えました！
(あとで個人的に使わせていただくかもしれません)
触発されたのでプルリクを作成させていただきました。)

### issue
同じ機種依存文字があった場合に初めの一文字しか赤くならない模様でした。
<img width="720" alt="2019-01-09 16 00 59" src="https://user-images.githubusercontent.com/33273390/50882367-e7fe6600-1427-11e9-91e8-94c985b14151.png">

### 実装
調査した結果、一旦splitしてjoinする形を推す記事が見つかったため、
splitからjoinしてみました。
※突貫であまりテストしていないため、何か問題になるケースが
見つかりましたらご指摘をいただけましたら幸いです。

### テスト
同じ機種依存文字があった場合に全部赤字になることを確認できました。
<img width="705" alt="2019-01-09 16 01 29" src="https://user-images.githubusercontent.com/33273390/50882513-54796500-1428-11e9-96b8-f8b673243b5f.png">
